### PR TITLE
✨ 게시물 상세 보기 구현

### DIFF
--- a/.idea/fashiony.iml
+++ b/.idea/fashiony.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (fashiony)" project-jdk-type="Python SDK" />
 </project>

--- a/app.py
+++ b/app.py
@@ -1,13 +1,16 @@
 from flask import Flask, render_template, jsonify, request, make_response
+from flask_uuid import FlaskUUID
 from config import CLIENT_ID, REDIRECT_URI
 from controller import Oauth
 
 import re
 import datetime
-import json
 import board
+import comment
+import json
 
 app = Flask(__name__)
+FlaskUUID(app)
 
 from pymongo import MongoClient
 
@@ -60,6 +63,13 @@ def oauth_userinfo_api():
 @app.route('/api/board', methods=['GET'])
 def board_entire_show():
     response = board.board_entire_show()
+    return jsonify(response)
+
+
+# 게시물에 대한 상세 정보를 내려주는 API
+@app.route('/api/board/<uuid:uid>', methods=['GET'])
+def board_detail_show(uid):
+    response = board.board_detail_show(uid)
     return jsonify(response)
 
 if __name__ == '__main__':

--- a/board.py
+++ b/board.py
@@ -43,3 +43,22 @@ def board_entire_show():
     }
 
     return response
+
+
+def board_detail_show(uid):
+    now = datetime.datetime.now()
+    time = now.strftime('%Y-%m-%d %H:%M:%S')
+
+    board = db.brandSnaps.find_one({'board.uuid': str(uid)}, {'_id': False})
+    if board is None:
+        response = {
+            'time': time,
+            'error': 'the post in that uuid does not exist',
+        }
+        return response
+
+    response = {
+        'time': time,
+        'data': board
+    }
+    return response


### PR DESCRIPTION
게시물 상세 보기를 구현하였습니다.

uuid 에 해당하는 게시물이 있는 경우 게시물의 정보를 내려주고 uuid 에 해당하는 게시물이 없을 경우 에러를 내려주도록 하였습니다.

uuid에 해당하는 게시물이 있는 경우
<img width="699" alt="스크린샷 2022-04-20 오후 5 35 16" src="https://user-images.githubusercontent.com/84092014/164186808-7a8dd8c1-2e90-4f67-a154-d89b80eda795.png">

uuid에 해당하는 게시물이 없는 경우
<img width="712" alt="스크린샷 2022-04-20 오후 5 36 04" src="https://user-images.githubusercontent.com/84092014/164186963-7f6ba5f0-abed-4316-9c06-ee5bc3d96528.png">

